### PR TITLE
fix(string-interpolation): operation headers not interpolated when req.headers is a HeaderMap

### DIFF
--- a/gateway/mesh.config.js
+++ b/gateway/mesh.config.js
@@ -5,9 +5,9 @@ module.exports = {
       handler: {
         graphql: {
           endpoint: 'http://localhost:4008',
-          operationHeaders: {
-            'access-token': "{context.req.headers.get('access-token')}",
-          },
+          operationHeaders: ({ context }) => ({
+            'access-token': context.req.headers.get('access-token'),
+          }),
         },
       },
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "prettier": "^2.8.4",
     "wait-port": "^1.0.4"
   },
+  "resolutions": {
+    "@graphql-mesh/string-interpolation": "npm:@pmrotule/graphql-mesh-string-interpolation@0.4.3-beta.2"
+  },
   "workspaces": [
     "services/*",
     "gateway"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,10 +1084,10 @@
     "@graphql-tools/utils" "9.2.1"
     tslib "^2.4.0"
 
-"@graphql-mesh/string-interpolation@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@graphql-mesh/string-interpolation/-/string-interpolation-0.4.2.tgz#4778ae192731e1dd21383560fcb278c60f25f9bb"
-  integrity sha512-xUSLpir2F4QlAZPVr9GTZ8fOeHYL4PCanykFhIH+CJRFWgolbsUSkTbNBUginQ8pjbQNFEpD2YGgz7N9aJKQ0w==
+"@graphql-mesh/string-interpolation@0.4.2", "@graphql-mesh/string-interpolation@npm:@pmrotule/graphql-mesh-string-interpolation@0.4.3-beta.2":
+  version "0.4.3-beta.2"
+  resolved "https://registry.yarnpkg.com/@pmrotule/graphql-mesh-string-interpolation/-/graphql-mesh-string-interpolation-0.4.3-beta.2.tgz#059b49eb816039df8f517607be790a5242b0c847"
+  integrity sha512-AHrJNipYpdGdICmidm4zH69LlDZ6kEJOomssjVrkgdRWbjmAnaK8+PwydUxV+sFjekxIbD7sWeU/hmhYLfh4Ww==
   dependencies:
     dayjs "1.11.7"
     json-pointer "0.6.2"


### PR DESCRIPTION
## Description

Considering how to set dynamic header values: https://the-guild.dev/graphql/mesh/docs/guides/headers

This PR allows the mesh config `operationHeaders` to be a function that returns the headers object. It takes the `resolverData` as first argument so we can have access to the `context.req.headers`. This fixes the issues where the `headers` object is a HeaderMap (you need to call `headers.get('key')`) which is not interpolated as expected:

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Sandbox

🚀 See it in action by checking out the [`fixed` branch](https://github.com/pmrotule/graphql-mesh-headers-not-interpolated/tree/fixed) of the issue reproduction repo. The changes of this PR has been published on npm under [@pmrotule/graphql-mesh-string-interpolation@0.4.3-beta.2](https://www.npmjs.com/package/@pmrotule/graphql-mesh-string-interpolation).

## How Has This Been Tested?

It has been tested in the issue reproduction repo and our real GraphQL Mesh integration (not tested on production yet). We still need to add test in this PR. Any guidance around tests would be appreciated since I haven't found any test regarding string interpolation.

**Test Environment**:

- OS: MacOS Monterey 12.6.1
- `@graphql-mesh/string-interpolation`: 0.4.2 (latest)
- NodeJS: 18.14.0
- `express`: 4.18.2 (latest)
- `@apollo/server`: 4.5.0 (latest)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I made the changes in the `string-interpolation` package even though it doesn't perform any string interpolation. It might be better to define it elsewhere, but I would love your feedback on that one.

We also started to get warnings from the JSON Schema validation of the mesh config, but I'm not sure where to update this (is it based on the Typescript types?).

<img width="608" alt="image" src="https://user-images.githubusercontent.com/10983258/225588505-8a49da17-4339-4209-a3f0-0c54d64c2ceb.png">

